### PR TITLE
Clean up process_docstring

### DIFF
--- a/keras_autodoc/docstring.py
+++ b/keras_autodoc/docstring.py
@@ -92,9 +92,7 @@ def get_code_blocks(docstring):
     return code_blocks, docstring
 
 
-def process_docstring(docstring):
-    # First, extract code blocks and process them.
-    code_blocks, docstring = get_code_blocks(docstring)
+def get_sections(docstring):
     # Format docstring lists.
     section_regex = r"\n( +)# (.*)\n"
     section_idx = re.search(section_regex, docstring)
@@ -117,6 +115,14 @@ def process_docstring(docstring):
         # `docstring` has changed, so we can't use `next_section_idx` anymore
         # we have to recompute it
         section_idx = re.search(section_regex, docstring[shift:])
+    return sections, docstring
+
+
+def process_docstring(docstring):
+    # First, extract code blocks and process them.
+    code_blocks, docstring = get_code_blocks(docstring)
+
+    sections, docstring = get_sections(docstring)
 
     # Format docstring section titles.
     docstring = re.sub(r"\n(\s+)# (.*)\n", r"\n\1__\2__\n\n", docstring)

--- a/keras_autodoc/docstring.py
+++ b/keras_autodoc/docstring.py
@@ -51,8 +51,7 @@ def process_list_block(docstring,
     return docstring, block
 
 
-def process_docstring(docstring):
-    # First, extract code blocks and process them.
+def get_code_blocks(docstring):
     code_blocks = []
     tmp = docstring[:]
     while "```" in tmp:
@@ -82,14 +81,20 @@ def process_docstring(docstring):
                 leading_spaces = spaces
         if leading_spaces:
             snippet_lines = (
-                [snippet_lines[0]]
-                + [line[leading_spaces:] for line in snippet_lines[1:-1]]
-                + [snippet_lines[-1]]
+                    [snippet_lines[0]]
+                    + [line[leading_spaces:] for line in snippet_lines[1:-1]]
+                    + [snippet_lines[-1]]
             )
         snippet = "\n".join(snippet_lines)
         code_blocks.append(snippet)
         tmp = tmp[index:]
 
+    return code_blocks, docstring
+
+
+def process_docstring(docstring):
+    # First, extract code blocks and process them.
+    code_blocks, docstring = get_code_blocks(docstring)
     # Format docstring lists.
     section_regex = r"\n( +)# (.*)\n"
     section_idx = re.search(section_regex, docstring)

--- a/keras_autodoc/docstring.py
+++ b/keras_autodoc/docstring.py
@@ -51,6 +51,22 @@ def process_list_block(docstring,
     return docstring, block
 
 
+def deindent_code(list_of_lines):
+    leading_spaces = None
+    for line in list_of_lines:
+        if not line or line[0] == "\n":
+            continue
+        spaces = utils.count_leading_spaces(line)
+        if leading_spaces is None:
+            leading_spaces = spaces
+        if spaces < leading_spaces:
+            leading_spaces = spaces
+    if leading_spaces:
+        return [line[leading_spaces:] for line in list_of_lines]
+    else:
+        return list_of_lines
+
+
 def get_code_blocks(docstring):
     code_blocks = []
     tmp = docstring[:]
@@ -69,22 +85,9 @@ def get_code_blocks(docstring):
         ]
         # Most code snippets have 3 or 4 more leading spaces
         # on inner lines, but not all. Remove them.
-        inner_lines = snippet_lines[1:-1]
-        leading_spaces = None
-        for line in inner_lines:
-            if not line or line[0] == "\n":
-                continue
-            spaces = utils.count_leading_spaces(line)
-            if leading_spaces is None:
-                leading_spaces = spaces
-            if spaces < leading_spaces:
-                leading_spaces = spaces
-        if leading_spaces:
-            snippet_lines = (
-                    [snippet_lines[0]]
-                    + [line[leading_spaces:] for line in inner_lines]
-                    + [snippet_lines[-1]]
-            )
+        snippet_lines = ([snippet_lines[0]]
+                         + deindent_code(snippet_lines[1:-1])
+                         + [snippet_lines[-1]])
         snippet = "\n".join(snippet_lines)
         code_blocks.append(snippet)
         tmp = tmp[index:]

--- a/keras_autodoc/docstring.py
+++ b/keras_autodoc/docstring.py
@@ -82,7 +82,7 @@ def get_code_blocks(docstring):
         if leading_spaces:
             snippet_lines = (
                     [snippet_lines[0]]
-                    + [line[leading_spaces:] for line in snippet_lines[1:-1]]
+                    + [line[leading_spaces:] for line in inner_lines]
                     + [snippet_lines[-1]]
             )
         snippet = "\n".join(snippet_lines)


### PR DESCRIPTION
Some much needed refactoring to see more clearly how we can use `inspect.getdoc` without breaking everything.