### PR TITLE
Fix support for variable-size indentation (e.g. 2-space indentation)

### DIFF
--- a/keras_autodoc/docstring.py
+++ b/keras_autodoc/docstring.py
@@ -65,8 +65,8 @@ def get_google_style_sections(docstring):
 def to_markdown(google_style_section: str) -> str:
     end_first_line = google_style_section.find('\n')
     section_title = google_style_section[2:end_first_line]
-    section_body = google_style_section[end_first_line + 1:]
-    section_body = utils.remove_indentation(section_body.strip())
+    section_body = google_style_section[end_first_line:]
+    section_body = utils.remove_indentation(section_body)
     if section_title in ('Arguments', 'Attributes', 'Raises'):
         # it's a list of elements, a special formatting is applied.
         section_body = format_as_markdown_list(section_body)

--- a/keras_autodoc/utils.py
+++ b/keras_autodoc/utils.py
@@ -116,10 +116,12 @@ def insert_in_string(target, string_to_insert, start, end):
 
 
 def remove_indentation(string):
-    string = string.replace('\n    ', '\n')
-    if string[:4] == '    ':
-        string = string[4:]
-    return string
+    lines = string.split('\n')
+    leading_spaces = [count_leading_spaces(l) for l in lines if l]
+    if leading_spaces:
+        min_leading_spaces = min(leading_spaces)
+        string = '\n'.join(l[min_leading_spaces:] for l in lines)
+    return string.strip()  # Drop leading/closing empty lines
 
 
 def get_dotted_path(class_):


### PR DESCRIPTION
I'm currently using keras-autodoc with tf.keras (2-space indented), but argument/attribute sections did not render properly. This fixes it.