### PR TITLE
Added the extra aliases arguments

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,5 @@
 # imported but unused in __init__.py, that's ok.
 per-file-ignores = **/__init__.py:F401
 
-max-line-length = 85
+# black manages this
+max-line-length = 93

--- a/keras_autodoc/autogen.py
+++ b/keras_autodoc/autogen.py
@@ -1,7 +1,7 @@
 import shutil
 import pathlib
 from inspect import getdoc, isclass, getfullargspec
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 from .docstring import process_docstring
 from .examples import copy_examples
@@ -29,18 +29,31 @@ class DocumentationGenerator:
             and then add the markdown file to the `pages` dictionary.
         example_dir: Where you store examples in your project. Usually standalone
             files with a markdown docstring at the top. Will be inserted in the docs.
+        extra_aliases: When displaying type hints, it's possible that the full
+            dotted path is displayed instead of alias. The aliases present in
+            `pages` are used, but it may happen if you're using a third-party library.
+            For example `tensorflow.python.ops.variables.Variable` is displayed instead
+            of `tensorflow.Variable`. Here you have two solutions, either you provide
+            the import keras-autodoc should follow:
+            `extra_aliases=["tensorflow.Variable"]`, either you provide a mapping to use
+            `extra_aliases={"tensorflow.python.ops.variables.Variable": "tf.Variable"}`.
+            The second option should be used if you want more control and that you
+            don't want to respect the alias corresponding to the import (you can't do
+            `import tf.Varaible`). When giving a list, keras-autodoc will try to import
+            the object from the string to understand what object you want to replace.
     """
     def __init__(self,
                  pages: Dict[str, list] = {},
                  project_url: Union[str, Dict[str, str]] = None,
                  template_dir=None,
-                 examples_dir=None):
+                 examples_dir=None,
+                 extra_aliases: Union[List[str], Dict[str, str]] =None):
         self.pages = pages
         self.project_url = project_url
         self.template_dir = template_dir
         self.examples_dir = examples_dir
         self.class_aliases = {}
-        self._fill_aliases()
+        self._fill_aliases(extra_aliases)
 
     def generate(self, dest_dir):
         """Generate the docs.
@@ -69,7 +82,7 @@ class DocumentationGenerator:
 
     def process_docstring(self, docstring, types: dict = None):
         """Can be overridden."""
-        processsed = process_docstring(docstring, types)
+        processsed = process_docstring(docstring, types, self.class_aliases)
         return processsed
 
     def process_signature(self, signature):
@@ -94,7 +107,7 @@ class DocumentationGenerator:
         subblocks = []
         if self.project_url is not None:
             subblocks.append(utils.make_source_link(object_, self.project_url))
-        signature = get_signature(object_, self.class_aliases, signature_override)
+        signature = get_signature(object_, signature_override)
         signature = self.process_signature(signature)
         subblocks.append(f"### {object_.__name__} {get_type(object_)}\n")
         subblocks.append(utils.code_snippet(signature))
@@ -107,7 +120,7 @@ class DocumentationGenerator:
             subblocks.append(docstring)
         return "\n\n".join(subblocks) + '\n\n----\n\n'
 
-    def _fill_aliases(self):
+    def _fill_aliases(self, extra_aliases):
         for list_elements in self.pages.values():
             for element_as_str in list_elements:
                 element = utils.import_object(element_as_str)
@@ -115,3 +128,10 @@ class DocumentationGenerator:
                     continue
                 true_dotted_path = utils.get_dotted_path(element)
                 self.class_aliases[true_dotted_path] = element_as_str
+
+        if isinstance(extra_aliases, dict):
+            self.class_aliases.update(extra_aliases)
+        elif isinstance(extra_aliases, list):
+            for alias in extra_aliases:
+                full_dotted_path = utils.get_dotted_path(utils.import_object(alias))
+                self.class_aliases[full_dotted_path] = alias

--- a/keras_autodoc/autogen.py
+++ b/keras_autodoc/autogen.py
@@ -47,7 +47,7 @@ class DocumentationGenerator:
                  project_url: Union[str, Dict[str, str]] = None,
                  template_dir=None,
                  examples_dir=None,
-                 extra_aliases: Union[List[str], Dict[str, str]] =None):
+                 extra_aliases: Union[List[str], Dict[str, str]] = None):
         self.pages = pages
         self.project_url = project_url
         self.template_dir = template_dir

--- a/keras_autodoc/get_signatures.py
+++ b/keras_autodoc/get_signatures.py
@@ -20,39 +20,37 @@ def get_signature_start(function):
     return f'{prefix}{function.__name__}'
 
 
-def get_signature_end(function, class_aliases={}):
+def get_signature_end(function):
     signature_end = Signature(function).format_args(show_annotation=False)
     if utils.ismethod(function):
         signature_end = signature_end.replace('(self, ', '(')
         signature_end = signature_end.replace('(self)', '()')
-    for dotted_path, alias in class_aliases.items():
-        signature_end = signature_end.replace(dotted_path, alias)
     return signature_end
 
 
-def get_function_signature(function, class_aliases={}, override=None):
+def get_function_signature(function, override=None):
     if override is None:
         signature_start = get_signature_start(function)
     else:
         signature_start = override
-    signature_end = get_signature_end(function, class_aliases)
+    signature_end = get_signature_end(function)
     return format_signature(signature_start, signature_end)
 
 
-def get_class_signature(cls, class_aliases={}, override=None):
+def get_class_signature(cls, override=None):
     if override is None:
         signature_start = f'{cls.__module__}.{cls.__name__}'
     else:
         signature_start = override
-    signature_end = get_signature_end(cls.__init__, class_aliases)
+    signature_end = get_signature_end(cls.__init__)
     return format_signature(signature_start, signature_end)
 
 
-def get_signature(object_, class_aliases, override):
+def get_signature(object_, override):
     if inspect.isclass(object_):
-        return get_class_signature(object_, class_aliases, override)
+        return get_class_signature(object_, override)
     else:
-        return get_function_signature(object_, class_aliases, override)
+        return get_function_signature(object_, override)
 
 
 def format_signature(signature_start: str, signature_end: str):

--- a/tests/test_autogen.py
+++ b/tests/test_autogen.py
@@ -526,15 +526,19 @@ def doing_things(an_argument: dummy_package.DataGenerator):
 
     """
 
+
 def test_rendinging_with_extra_alias():
     extra_aliases = ["tests.dummy_package.DataGenerator"]
-    generated = autogen.DocumentationGenerator(extra_aliases=extra_aliases)._render(doing_things)
+    generated = autogen.DocumentationGenerator(extra_aliases=extra_aliases)._render(
+        doing_things)
     assert "- __an_argument__ `tests.dummy_package.DataGenerator`: Some" in generated
 
 
 def test_rendinging_with_extra_alias_custom_alias():
-    extra_aliases = {"tests.dummy_package.dummy_module.ImageDataGenerator": "some.new.Thing"}
-    generated = autogen.DocumentationGenerator(extra_aliases=extra_aliases)._render(doing_things)
+    extra_aliases = {"tests.dummy_package.dummy_module.ImageDataGenerator":
+                     "some.new.Thing"}
+    generated = autogen.DocumentationGenerator(extra_aliases=extra_aliases)._render(
+        doing_things)
     assert "- __an_argument__ `some.new.Thing`: Some" in generated
 
 

--- a/tests/test_autogen.py
+++ b/tests/test_autogen.py
@@ -5,6 +5,7 @@ import pytest
 import pathlib
 from typing import Union, Optional, Tuple
 from .dummy_package import dummy_module
+from . import dummy_package
 
 test_doc1 = {
     "doc": """Base class for recurrent layers.
@@ -515,6 +516,26 @@ def test_hard_method():
 
     assert "- __arg__ `Union[int, Tuple[int, int]]`: One or" in generated
     assert "- __arg2__ `int`: One integer." in generated
+
+
+def doing_things(an_argument: dummy_package.DataGenerator):
+    """A function
+
+    # Arguments
+        an_argument: Some generator
+
+    """
+
+def test_rendinging_with_extra_alias():
+    extra_aliases = ["tests.dummy_package.DataGenerator"]
+    generated = autogen.DocumentationGenerator(extra_aliases=extra_aliases)._render(doing_things)
+    assert "- __an_argument__ `tests.dummy_package.DataGenerator`: Some" in generated
+
+
+def test_rendinging_with_extra_alias_custom_alias():
+    extra_aliases = {"tests.dummy_package.dummy_module.ImageDataGenerator": "some.new.Thing"}
+    generated = autogen.DocumentationGenerator(extra_aliases=extra_aliases)._render(doing_things)
+    assert "- __an_argument__ `some.new.Thing`: Some" in generated
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a new argument `extra_aliases` to allow users to customize how type hints are displayed.

description:

When displaying type hints, it's possible that the full dotted path is displayed instead of alias. The aliases present in `pages` are used, but it may happen if you're using a third-party library.

For example `tensorflow.python.ops.variables.Variable` is displayed instead of `tensorflow.Variable`.

Here you have two solutions, either you provide the import keras-autodoc should follow:
`extra_aliases=["tensorflow.Variable"]`, either you provide a mapping to use `extra_aliases={"tensorflow.python.ops.variables.Variable": "tf.Variable"}`. 

The second option should be used if you want more control and that you don't want to respect the alias corresponding to the import (you can't do `import tf.Variable`). 
When giving a list, keras-autodoc will try to import the object from the string to understand what object you want to replace.


@leonoverweel could you try this pull request with 
```
pip install git+https://github.com/gabrieldemarmiesse/keras-autodoc.git@add_aliases_for_type_hints
```
with the `extra_aliases` argument? I should display all the type hints with TF objects nicely :)