### PR TITLE
Remove object type from header

### DIFF
--- a/keras_autodoc/autogen.py
+++ b/keras_autodoc/autogen.py
@@ -117,7 +117,7 @@ class DocumentationGenerator:
             object_, signature_override, self.max_signature_line_length
         )
         signature = self.process_signature(signature)
-        subblocks.append(f"### {object_.__name__} {get_type(object_)}\n")
+        subblocks.append(f"### {object_.__name__}\n")
         subblocks.append(utils.code_snippet(signature))
 
         docstring = getdoc(object_)

--- a/keras_autodoc/autogen.py
+++ b/keras_autodoc/autogen.py
@@ -8,7 +8,6 @@ from .examples import copy_examples
 from .get_signatures import get_signature
 
 from . import utils
-from .utils import get_type
 
 
 class DocumentationGenerator:

--- a/tests/dummy_package/expected.md
+++ b/tests/dummy_package/expected.md
@@ -1,6 +1,6 @@
 <span style="float:right;">[[source]](www.dummy.com/my_project/tests/dummy_package/dummy_module.py#L1)</span>
 
-### Dense class
+### Dense
 
 
 ```python
@@ -89,7 +89,7 @@ the output would have shape `(batch_size, units)`.
 
 <span style="float:right;">[[source]](www.dummy.com/my_project/tests/dummy_package/dummy_module.py#L113)</span>
 
-### ImageDataGenerator class
+### ImageDataGenerator
 
 
 ```python
@@ -326,7 +326,7 @@ model.fit_generator(
 
 <span style="float:right;">[[source]](www.dummy.com/my_project/tests/dummy_package/dummy_module.py#L340)</span>
 
-### flow method
+### flow
 
 
 ```python
@@ -394,7 +394,7 @@ If `y` is None, only the numpy array `x` is returned.
 
 <span style="float:right;">[[source]](www.dummy.com/my_project/tests/dummy_package/dummy_module.py#L395)</span>
 
-### flow_from_directory method
+### flow_from_directory
 
 
 ```python
@@ -498,7 +498,7 @@ and `y` is a numpy array of corresponding labels.
 
 <span style="float:right;">[[source]](www.dummy.com/my_project/tests/dummy_package/dummy_module.py#L78)</span>
 
-### to_categorical function
+### to_categorical
 
 
 ```python

--- a/tests/test_autogen.py
+++ b/tests/test_autogen.py
@@ -440,7 +440,7 @@ def test_aliases_methods(element, expected):
     assert expected in computed
 
 
-expected_dodo = """### dodo function
+expected_dodo = """### dodo
 
 
 ```python


### PR DESCRIPTION
This PR removes the object's type from docs headers; closes #82.