### PR TITLE
support the latest sphinx version

### DIFF
--- a/keras_autodoc/get_signatures.py
+++ b/keras_autodoc/get_signatures.py
@@ -2,7 +2,8 @@ import warnings
 from . import utils
 import black
 import inspect
-from sphinx.util.inspect import Signature
+from sphinx.util.inspect import signature
+from sphinx.util.inspect import stringify_signature
 
 
 def get_signature_start(function):
@@ -21,7 +22,8 @@ def get_signature_start(function):
 
 
 def get_signature_end(function):
-    signature_end = Signature(function).format_args(show_annotation=False)
+    sig = signature(function)
+    signature_end = stringify_signature(sig, show_annotation=False)
     if utils.ismethod(function):
         signature_end = signature_end.replace('(self, ', '(')
         signature_end = signature_end.replace('(self)', '()')

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='keras-autodoc',
     version='0.8.0',
     packages=find_packages(),
-    install_requires=['markdown', 'sphinx', 'black'],
+    install_requires=['markdown', 'sphinx', 'black==22.8.0'],
     package_data={'': ['README.md']},
     author='The Keras team',
     author_email='gabrieldemarmiesse@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ readme = this_file.parent / 'README.md'
 
 setup(
     name='keras-autodoc',
-    version='0.7.0',
+    version='0.8.0',
     packages=find_packages(),
-    install_requires=['markdown', 'sphinx', 'black==20.8b1'],
+    install_requires=['markdown', 'sphinx', 'black'],
     package_data={'': ['README.md']},
     author='The Keras team',
     author_email='gabrieldemarmiesse@gmail.com',
@@ -19,13 +19,15 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/keras-team/keras-autodoc',
     license='Apache License 2.0',
-    extras_require={'tests': ['pytest', 'pytest-pep8']},
+    extras_require={'tests': ['pytest', 'pytest-pep8', 'keras-tuner', 'tensorflow>=2.9.1']},
     classifiers=[
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Utilities',
         'Topic :: Documentation',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,38 +1,25 @@
-FROM python:3.6 as base_image
+FROM python:3.7 as base_image
 
 RUN pip install tensorflow
-RUN pip install markdown mkdocs pytest sphinx black==19.10b0
-
-FROM python:3.7 as base_image_37
-
-RUN pip install tensorflow
-RUN pip install markdown mkdocs pytest sphinx black==19.10b0
+RUN pip install markdown mkdocs pytest sphinx
 
 FROM base_image as integration_tests
-RUN pip install keras==2.3.0
-RUN pip install git+https://github.com/keras-team/keras-tuner.git@1.0rc0
 COPY ./ ./keras-autodoc
-RUN pip install -e ./keras-autodoc
+RUN pip install -e "./keras-autodoc[tests]"
 WORKDIR keras-autodoc
 RUN pytest tests/test_integration.py
 
-FROM base_image as unit_tests
+FROM base_image as unit_tests_py
 COPY ./ ./keras-autodoc
 RUN pip install -e ./keras-autodoc
 WORKDIR keras-autodoc
 RUN pytest --ignore=tests/test_integration.py tests/
 
-FROM base_image_37 as unit_tests_py37
-COPY ./ ./keras-autodoc
-RUN pip install -e ./keras-autodoc
-WORKDIR keras-autodoc
-RUN pytest --ignore=tests/test_integration.py tests/
-
-FROM base_image_37 as flake8_tests
+FROM base_image as flake8_tests
 RUN pip install flake8
 COPY ./ ./keras-autodoc
 WORKDIR keras-autodoc
-RUN flake8
+RUN flake8 .
 
 FROM base_image as doc_tests
 COPY ./ ./keras-autodoc

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,17 +1,18 @@
-from keras import Model
-from kerastuner import HyperParameters
+from tensorflow.keras import Model
+from keras_tuner import HyperParameters
 from keras_autodoc.get_signatures import get_function_signature, get_signature_end
 
 
 def test_signature():
     excpected = ('Model.compile(\n'
-                 '    optimizer,\n'
+                 '    optimizer="rmsprop",\n'
                  '    loss=None,\n'
                  '    metrics=None,\n'
                  '    loss_weights=None,\n'
-                 '    sample_weight_mode=None,\n'
                  '    weighted_metrics=None,\n'
-                 '    target_tensors=None,\n'
+                 '    run_eagerly=None,\n'
+                 '    steps_per_execution=None,\n'
+                 '    jit_compile=None,\n'
                  '    **kwargs\n'
                  ')')
     computed = get_function_signature(Model.compile)


### PR DESCRIPTION
AutoKeras is depending on this library to generate the docs.
We need a new release of keras-autodoc to support the latest Python version and sphinx version.
So updated the autodoc version to 0.8.0 for release.

Removed py3.6 test from docker.
Updated black to a stable version.